### PR TITLE
Sending only 16 times the MAC not 17 times

### DIFF
--- a/index.js
+++ b/index.js
@@ -17,7 +17,7 @@ function createMagicPacket(mac){
   var buffer = Buffer.alloc(PACKET_HEADER);
   var bufMac = Buffer.from(parts.map(p => parseInt(p, 16)));
   buffer.fill(0xff);
-  for(var i = 0; i < MAC_REPEAT; i++){
+  for(var i = 1; i < MAC_REPEAT; i++){
     buffer = Buffer.concat([ buffer, bufMac ]);
   }
   return buffer;


### PR DESCRIPTION
A first copy is made by :
     var bufMac = Buffer.from(parts.map(p => parseInt(p, 16)));

Adding MAC_REPEAT times more ends up with one too many packets.

Fixed that.