### PR TITLE
Change promise result to be consistant with callback

### DIFF
--- a/index.js
+++ b/index.js
@@ -52,9 +52,10 @@ function wake(mac, options, callback){
     socket.send(
       magicPacket, 0, magicPacket.length,
       port, address, function(err, res){
+        let result = res == magicPacket.length;
         if(err) reject(err);
-        else resolve(res);
-        callback && callback(err, res == magicPacket.length);
+        else resolve(result);
+        callback && callback(err, result);
         socket.close();
     });
   });


### PR DESCRIPTION
## Why
To be able to get the bool result from the promise when calling `await wol.wake()` in order to bulk return an error message from a http server

## Usage
```javascript

async function someFunc(devices){
  let failed = []
  for (let i=0; i< devices.length; i++){
    let result = false;
    try{
      result = await wol.wake(devices[i])
    }catch(e){}
    
    if(!result){
      failed.push(device)
    }
  }
  
  // Handle failed devices in bulk
}
```
