### PR TITLE
Stabilize wake() socket flow: explicit bind, proper broadcast, safe teardown

### DIFF
--- a/index.js
+++ b/index.js
@@ -45,18 +45,21 @@ function wake(mac, options, callback){
   ).on('error', function(err){
     socket.close();
     callback && callback(err);
-  }).once('listening', function(){
-    socket.setBroadcast(true);
   });
+
   return new Promise((resolve, reject) => {
-    socket.send(
-      magicPacket, 0, magicPacket.length,
-      port, address, function(err, res){
-        let result = res == magicPacket.length;
-        if(err) reject(err);
-        else resolve(result);
-        callback && callback(err, result);
-        socket.close();
+    socket.bind(0, function() {
+      socket.setBroadcast(true);
+
+      socket.send(
+          magicPacket, 0, magicPacket.length,
+          port, address, function(err, res){
+            let result = res == magicPacket.length;
+            if(err) reject(err);
+            else resolve(result);
+            callback && callback(err, result);
+            socket.close();
+          });
     });
   });
 };

--- a/index.js
+++ b/index.js
@@ -54,11 +54,14 @@ function wake(mac, options, callback){
       socket.send(
           magicPacket, 0, magicPacket.length,
           port, address, function(err, res){
-            let result = res == magicPacket.length;
-            if(err) reject(err);
-            else resolve(result);
-            callback && callback(err, result);
-            socket.close();
+            try {
+              let result = res == magicPacket.length;
+              if(err) reject(err);
+              else resolve(result);
+              callback && callback(err, result);
+            } finally {
+              socket.close();
+            }
           });
     });
   });


### PR DESCRIPTION
## 📑 Description
This pull request refactors the socket handling logic in the `wake` function in `index.js` to improve reliability and ensure proper socket closure. The most important changes are:

* Moved the `socket.setBroadcast(true)` and `socket.send` call to occur after the socket is bound, ensuring broadcast is enabled at the correct time.
* Ensured the socket is always closed after sending the magic packet, using a `finally` block.


## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [X] My pull request adheres to the code style of this project
- [ ] My code requires changes to the documentation
- [ ] I have updated the documentation as required
- [X] All the tests have passed